### PR TITLE
Optimize CPU from streams to direct list

### DIFF
--- a/bonsai-core/src/main/java/com/phonepe/commons/bonsai/core/vital/BonsaiTree.java
+++ b/bonsai-core/src/main/java/com/phonepe/commons/bonsai/core/vital/BonsaiTree.java
@@ -491,11 +491,17 @@ public class BonsaiTree<C extends Context> implements Bonsai<C> {
             public KeyNode visit(final MultiKnotData multiKnotData) {
                 /* recursively evaluate the list of keys in MultiKnot */
                 final List<String> keys = multiKnotData.getKeys();
-                final List<KeyNode> nodes = keys != null
-                        ? keys.stream()
-                        .map(key -> evaluate(key, context))
-                        .toList()
-                        : null;
+                List<KeyNode> nodes = new ArrayList<>();
+
+                if (keys != null) {
+                    for (String key : keys) {
+                        KeyNode node = evaluate(key, context);
+                        if (node != null) {
+                            nodes.add(node);
+                        }
+                    }
+                }
+
                 return new KeyNode(key,
                                    ListNode.builder()
                                            .id(knot.getId())


### PR DESCRIPTION
The `toList` at the end of the stream is an expensive operation. JFR shows 27% of CPU time spent here. Switch this code to vanilla iteration.

<img width="842" alt="Screenshot 2025-04-04 at 3 38 34 PM" src="https://github.com/user-attachments/assets/9f86401f-b7f7-413c-a446-30a34c7a90f0" />
