### PR TITLE
Fix: Wrong edge path number in evaluation after variation deletion

### DIFF
--- a/bonsai-core/src/main/java/com/phonepe/commons/bonsai/core/vital/BonsaiTree.java
+++ b/bonsai-core/src/main/java/com/phonepe/commons/bonsai/core/vital/BonsaiTree.java
@@ -747,7 +747,7 @@ public class BonsaiTree<C extends Context> implements Bonsai<C> {
         /* recursively iterate over the matching edge knot on the RHS (knot --edge--> rhsKnot) */
         Edge edge = conditionSatisfyingEdge.get();
         Knot rhsKnot = knotStore.getKnot(edge.getKnotId());
-        path.add(edge.getEdgeIdentifier().getNumber());
+        path.add(getEdgePositionInCurrentEdges(edge.getEdgeIdentifier(), edgeIdentifiers));
         if (log.isDebugEnabled()) {
             log.debug("[bonsai][getMatchingKnot][{}][{}] edge condition satisfied: {}, knot: {} ", context.id(), key,
                     edge.getEdgeIdentifier().getId(), rhsKnot.getId());
@@ -875,6 +875,17 @@ public class BonsaiTree<C extends Context> implements Bonsai<C> {
                 recursivelyCalculateDeltaOperations(getKnot(edge.getKnotId()), operations);
             }
         }
+    }
+
+    private Integer getEdgePositionInCurrentEdges(final EdgeIdentifier edge, final OrderedList<EdgeIdentifier> edges) {
+        String requiredEdgeId = edge.getId();
+        for (int i = 0; i < edges.size(); i++) {
+            if(requiredEdgeId.equals(edges.get(i).getId())) {
+                return i+1; // Edge number is 1 indexed
+            }
+        }
+        throw new BonsaiError(BonsaiErrorCode.EDGE_ABSENT,
+                              "No edge found in knots edges for edgeId: " + edge.getId());
     }
 
 }


### PR DESCRIPTION
Consider the scneario with 4 edges like below:  
![image](https://github.com/user-attachments/assets/17460225-4491-4599-b37a-8dbfc2b8761e)

**Issue**
Response of evaluation contains `edgePath` which stores the path in which the edges were successfully chosen.  
Now suppose the edge with filter `userId = U3` gets deleted. Here the number of edge with filter `userId = 4` still remains 4.  
However, this edgeNumber is used in edgePath tracing during evaluation of a key. So what happens is that now suppose context map was `userId = 4` then the correct edge with filter `userId = 4` gets evaluated however the edgePath response is `[4]` instead of `[3]` (which is the current position of the edge of U4 in the list of edges of `rootKnot`

**Fix**
Instead of getting the edge position from edge's number, we instead calculate the position of edge in list of `edgeIdentifiers` of a knot by iterating the list and finding the position.
