### PR TITLE
added associatedEntity field

### DIFF
--- a/bonsai-conditions/src/main/java/com/phonepe/commons/bonsai/conditions/ConditionDependantEngine.java
+++ b/bonsai-conditions/src/main/java/com/phonepe/commons/bonsai/conditions/ConditionDependantEngine.java
@@ -16,11 +16,14 @@
 
 package com.phonepe.commons.bonsai.conditions;
 
-public abstract class ConditionDependantEngine<C extends Condition> extends ConditionEngine<Void, C> {
+public abstract class ConditionDependantEngine<C extends Condition> extends ConditionEngine<Void, C, Void> {
     public abstract Boolean match(C c);
 
     @Override
     public Boolean match(Void entity, C c) {
         return match(c);
     }
+
+    @Override
+    public Boolean match(Void entity, C c, Void context ) {return match(c);}
 }

--- a/bonsai-conditions/src/main/java/com/phonepe/commons/bonsai/conditions/ConditionDependantEngine.java
+++ b/bonsai-conditions/src/main/java/com/phonepe/commons/bonsai/conditions/ConditionDependantEngine.java
@@ -25,5 +25,5 @@ public abstract class ConditionDependantEngine<C extends Condition> extends Cond
     }
 
     @Override
-    public Boolean match(Void entity, C c, Void context ) {return match(c);}
+    public Boolean match(Void entity, C c, Void context) {return match(c);}
 }

--- a/bonsai-conditions/src/main/java/com/phonepe/commons/bonsai/conditions/ConditionEngine.java
+++ b/bonsai-conditions/src/main/java/com/phonepe/commons/bonsai/conditions/ConditionEngine.java
@@ -57,14 +57,14 @@ public abstract class ConditionEngine<E, C extends Condition, F> implements Matc
      *
      * @param entity        contender
      * @param conditions condition to be matched
-     * @param associatedEntity An additional entity or piece of context that can be used to provide more nuanced filtering logic.
+     * @param entityMetadata An additional entity or piece of context that can be used to provide more nuanced filtering logic.
      * @return matching criteria
      */
     @Override
-    public Optional<C> match(E entity, final List<C> conditions, F associatedEntity) {
+    public Optional<C> match(E entity, final List<C> conditions, F entityMetadata) {
         return conditions.stream()
                 .filter(condition -> condition.isLive() && (RANDOM_MATCHER.match(condition.getPercentage()) && match(
-                        entity, condition, associatedEntity)))
+                        entity, condition, entityMetadata)))
                 .findFirst();
     }
 

--- a/bonsai-conditions/src/main/java/com/phonepe/commons/bonsai/conditions/ConditionEngine.java
+++ b/bonsai-conditions/src/main/java/com/phonepe/commons/bonsai/conditions/ConditionEngine.java
@@ -30,7 +30,7 @@ import java.util.function.BooleanSupplier;
 /**
  * An abstract conditional matcher, who matches an entity against a list of conditions
  */
-public abstract class ConditionEngine<E, C extends Condition> implements Matcher.ConditionalMatcher<E, C> {
+public abstract class ConditionEngine<E, C extends Condition, F> implements Matcher.ConditionalMatcher<E, C, F> {
 
     /**
      * a random matcher to check applicability of a criteria, which is configured with a percentage
@@ -49,6 +49,22 @@ public abstract class ConditionEngine<E, C extends Condition> implements Matcher
         return conditions.stream()
                 .filter(condition -> condition.isLive() && (RANDOM_MATCHER.match(condition.getPercentage()) && match(
                         entity, condition)))
+                .findFirst();
+    }
+
+    /**
+     * check if the condition matches the contender
+     *
+     * @param entity        contender
+     * @param conditions condition to be matched
+     * @param associatedEntity An additional entity or piece of context that can be used to provide more nuanced filtering logic.
+     * @return matching criteria
+     */
+    @Override
+    public Optional<C> match(E entity, final List<C> conditions, F associatedEntity) {
+        return conditions.stream()
+                .filter(condition -> condition.isLive() && (RANDOM_MATCHER.match(condition.getPercentage()) && match(
+                        entity, condition, associatedEntity)))
                 .findFirst();
     }
 

--- a/bonsai-conditions/src/main/java/com/phonepe/commons/bonsai/conditions/ConditionEngines.java
+++ b/bonsai-conditions/src/main/java/com/phonepe/commons/bonsai/conditions/ConditionEngines.java
@@ -22,14 +22,19 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ConditionEngines {
 
-    public static class TrueConditionEngine<C extends Condition> extends ConditionEngine<Void, C> {
+    public static class TrueConditionEngine<C extends Condition, F> extends ConditionEngine<Void, C, F> {
         @Override
         public Boolean match(Void v1, C c) {
             return true;
         }
+
+        @Override
+        public Boolean match(Void v1, C c, F v2) {
+            return true;
+        }
     }
 
-    public static <C extends Condition> ConditionEngine<Void, C> trueConditionEngine() {
+    public static <C extends Condition, F> ConditionEngine<Void, C, F> trueConditionEngine() {
         return new TrueConditionEngine<>();
     }
 }

--- a/bonsai-conditions/src/main/java/com/phonepe/commons/bonsai/conditions/Matcher.java
+++ b/bonsai-conditions/src/main/java/com/phonepe/commons/bonsai/conditions/Matcher.java
@@ -84,19 +84,19 @@ public class Matcher {
          *
          * @param v1               The contending entity to be evaluated.
          * @param conditionList       A list of conditions to match against.
-         * @param associatedEntity An additional entity that provides context for the matching logic.
+         * @param entityMetadata An additional entity that provides context for the matching logic.
          * @return An Optional containing the first matching condition, or an empty Optional if no match is found.
          */
-        Optional<C> match(V v1, List<C> conditionList, F associatedEntity);
+        Optional<C> match(V v1, List<C> conditionList, F entityMetadata);
 
         /**
          * Checks if a single condition matches the contending entity, using an additional associated entity.
          *
          * @param v1               The contending entity to be evaluated.
          * @param condition        The single condition to match against.
-         * @param associatedEntity An additional entity that provides context for the matching logic.
+         * @param entityMetadata An additional entity that provides context for the matching logic.
          * @return `true` if the condition is a match, otherwise `false`.
          */
-        Boolean match(V v1, C condition, F associatedEntity);
+        Boolean match(V v1, C condition, F entityMetadata);
     }
 }

--- a/bonsai-conditions/src/main/java/com/phonepe/commons/bonsai/conditions/Matcher.java
+++ b/bonsai-conditions/src/main/java/com/phonepe/commons/bonsai/conditions/Matcher.java
@@ -55,8 +55,9 @@ public class Matcher {
      *
      * @param <V>         contending entity
      * @param <C> list of condition to be matched with
+     * @param <F> An associated entity providing additional context for filtering.
      */
-    public interface ConditionalMatcher<V, C> {
+    public interface ConditionalMatcher<V, C, F> {
 
         /**
          * Try to match a contending entity with a Collection of Criteria,
@@ -76,5 +77,26 @@ public class Matcher {
          * @return true if there is a match
          */
         Boolean match(V v1, C condition);
+
+        /**
+         * Tries to match a contending entity against a list of conditions, using an additional associated entity for more complex filtering.
+         * This allows for nuanced logic where the match criteria might depend on both the primary entity and some other contextual data (e.g., using an evaluation key for uniform sampling).
+         *
+         * @param v1               The contending entity to be evaluated.
+         * @param conditionList       A list of conditions to match against.
+         * @param associatedEntity An additional entity that provides context for the matching logic.
+         * @return An Optional containing the first matching condition, or an empty Optional if no match is found.
+         */
+        Optional<C> match(V v1, List<C> conditionList, F associatedEntity);
+
+        /**
+         * Checks if a single condition matches the contending entity, using an additional associated entity.
+         *
+         * @param v1               The contending entity to be evaluated.
+         * @param condition        The single condition to match against.
+         * @param associatedEntity An additional entity that provides context for the matching logic.
+         * @return `true` if the condition is a match, otherwise `false`.
+         */
+        Boolean match(V v1, C condition, F associatedEntity);
     }
 }

--- a/bonsai-conditions/src/main/java/com/phonepe/commons/bonsai/conditions/Matcher.java
+++ b/bonsai-conditions/src/main/java/com/phonepe/commons/bonsai/conditions/Matcher.java
@@ -80,7 +80,7 @@ public class Matcher {
 
         /**
          * Tries to match a contending entity against a list of conditions, using an additional associated entity for more complex filtering.
-         * This allows for nuanced logic where the match criteria might depend on both the primary entity and some other contextual data (e.g., using an evaluation key for uniform sampling).
+         * This allows for nuanced logic where the match criteria might depend on both the primary entity and some other contextual data.
          *
          * @param v1               The contending entity to be evaluated.
          * @param conditionList       A list of conditions to match against.

--- a/bonsai-conditions/src/test/java/com/phonepe/commons/bonsai/conditions/ConditionEngineTest.java
+++ b/bonsai-conditions/src/test/java/com/phonepe/commons/bonsai/conditions/ConditionEngineTest.java
@@ -217,23 +217,15 @@ class ConditionEngineTest {
 
     @Test
     void testMatch() {
-        // Setup test data
         TestCondition condition1 = new TestCondition(true, 100f);
         TestCondition condition2 = new TestCondition(true, 75f);
         TestCondition condition3 = new TestCondition(false, 100f);
         List<TestCondition> conditions = Arrays.asList(condition1, condition2, condition3);
-
-        // Create a test implementation with mock behavior
         TestConditionEngine engineSpy = spy(conditionEngine);
-
-        // Configure the mocked behavior directly
         when(engineSpy.match("test", condition1)).thenReturn(true);
         when(engineSpy.match("test", condition2)).thenReturn(false);
-
-        // Test the match method without modifying RANDOM_MATCHER
         Optional<TestCondition> result = engineSpy.match("test", conditions);
 
-        // Verify correct condition was returned
         assertTrue(result.isPresent());
         assertEquals(condition1, result.get());
 
@@ -243,30 +235,23 @@ class ConditionEngineTest {
 
     @Test
     void testMatchWithAssociatedEntity_ShouldReturnFirstMatchingCondition() {
-        // Setup test data
         TestCondition condition1 = new TestCondition(true, 100f);
         TestCondition condition2 = new TestCondition(true, 75f);
         List<TestCondition> conditions = Arrays.asList(condition1, condition2);
         String testKey = "user_group_A";
 
-        // Create a spy to verify method calls
         TestConditionEngine engineSpy = spy(conditionEngine);
 
-        // Configure mocked behavior for the 3-argument match method
         when(engineSpy.match("test", condition1, testKey)).thenReturn(true);
         when(engineSpy.match("test", condition2, testKey)).thenReturn(false);
 
-        // Act: Call the match method with the associated entity
         Optional<TestCondition> result = engineSpy.match("test", conditions, testKey);
 
-        // Assert: Verify the correct condition was returned
         assertTrue(result.isPresent());
         assertEquals(condition1, result.get());
 
-        // Verify that the 3-argument match method was called for the first condition
         verify(engineSpy).match("test", condition1, testKey);
 
-        // Verify that the 2-argument match overload was never called for this flow
         verify(engineSpy, never()).match("test", condition1);
     }
 

--- a/bonsai-conditions/src/test/java/com/phonepe/commons/bonsai/conditions/ConditionEngineTest.java
+++ b/bonsai-conditions/src/test/java/com/phonepe/commons/bonsai/conditions/ConditionEngineTest.java
@@ -234,7 +234,7 @@ class ConditionEngineTest {
     }
 
     @Test
-    void testMatchWithAssociatedEntity_ShouldReturnFirstMatchingCondition() {
+    void testMatchWithEntityMetadata_ShouldReturnFirstMatchingCondition() {
         TestCondition condition1 = new TestCondition(true, 100f);
         TestCondition condition2 = new TestCondition(true, 75f);
         List<TestCondition> conditions = Arrays.asList(condition1, condition2);
@@ -263,7 +263,7 @@ class ConditionEngineTest {
         }
 
         @Override
-        public Boolean match(String entity, TestCondition condition, String associatedEntity) {
+        public Boolean match(String entity, TestCondition condition, String entityMetadata) {
             // Default implementation for the new match logic, will be mocked in tests.
             return true;
         }

--- a/bonsai-conditions/src/test/java/com/phonepe/commons/bonsai/conditions/ConditionEngineTest.java
+++ b/bonsai-conditions/src/test/java/com/phonepe/commons/bonsai/conditions/ConditionEngineTest.java
@@ -241,11 +241,46 @@ class ConditionEngineTest {
         verify(engineSpy, never()).match("test", condition3);
     }
 
+    @Test
+    void testMatchWithAssociatedEntity_ShouldReturnFirstMatchingCondition() {
+        // Setup test data
+        TestCondition condition1 = new TestCondition(true, 100f);
+        TestCondition condition2 = new TestCondition(true, 75f);
+        List<TestCondition> conditions = Arrays.asList(condition1, condition2);
+        String testKey = "user_group_A";
+
+        // Create a spy to verify method calls
+        TestConditionEngine engineSpy = spy(conditionEngine);
+
+        // Configure mocked behavior for the 3-argument match method
+        when(engineSpy.match("test", condition1, testKey)).thenReturn(true);
+        when(engineSpy.match("test", condition2, testKey)).thenReturn(false);
+
+        // Act: Call the match method with the associated entity
+        Optional<TestCondition> result = engineSpy.match("test", conditions, testKey);
+
+        // Assert: Verify the correct condition was returned
+        assertTrue(result.isPresent());
+        assertEquals(condition1, result.get());
+
+        // Verify that the 3-argument match method was called for the first condition
+        verify(engineSpy).match("test", condition1, testKey);
+
+        // Verify that the 2-argument match overload was never called for this flow
+        verify(engineSpy, never()).match("test", condition1);
+    }
+
     // Test implementation of ConditionEngine for testing
-    private static class TestConditionEngine extends ConditionEngine<String, TestCondition> {
+    private static class TestConditionEngine extends ConditionEngine<String, TestCondition, String> {
         @Override
         public Boolean match(String entity, TestCondition condition) {
             return true; // Default implementation, will be mocked in test
+        }
+
+        @Override
+        public Boolean match(String entity, TestCondition condition, String associatedEntity) {
+            // Default implementation for the new match logic, will be mocked in tests.
+            return true;
         }
     }
 

--- a/bonsai-conditions/src/test/java/com/phonepe/commons/bonsai/conditions/ConditionEnginesTest.java
+++ b/bonsai-conditions/src/test/java/com/phonepe/commons/bonsai/conditions/ConditionEnginesTest.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class ConditionEnginesTest {
 
-    private ConditionEngine<Void, TestCondition> trueConditionEngine;
+    private ConditionEngine<Void, TestCondition, String> trueConditionEngine;
     private TestCondition condition1;
     private TestCondition condition2;
     private List<TestCondition> conditions;
@@ -100,6 +100,57 @@ class ConditionEnginesTest {
         // Should return the first live condition
         assertTrue(result.isPresent());
         assertEquals(liveCondition, result.get());
+    }
+
+    /**
+     * Verifies that the 3-argument match overload also always returns true for a live condition.
+     */
+    @Test
+    void testTrueConditionEngineMatchWithAssociatedEntity() {
+        // Test that TrueConditionEngine always returns true, ignoring the associated entity.
+        assertTrue(trueConditionEngine.match(null, condition1, "any-key"));
+        assertTrue(trueConditionEngine.match(null, condition2, "another-key"));
+    }
+
+    /**
+     * Verifies the list-based match overload with an associated entity returns the first live condition.
+     */
+    @Test
+    void testTrueConditionEngineMatchWithListAndAssociatedEntity() {
+        // Test match with a list and an associated entity.
+        Optional<TestCondition> result = trueConditionEngine.match(null, conditions, "any-key");
+
+        // Should still return the first live condition, ignoring the key.
+        assertTrue(result.isPresent());
+        assertEquals(condition1, result.get());
+    }
+
+    /**
+     * Verifies that passing an associated entity to an empty list still results in an empty optional.
+     */
+    @Test
+    void testTrueConditionEngineMatchWithEmptyListAndAssociatedEntity() {
+        // Test match with an empty list and an associated entity.
+        Optional<TestCondition> result = trueConditionEngine.match(null, Collections.emptyList(), "any-key");
+
+        // Should return an empty Optional for an empty list.
+        assertFalse(result.isPresent());
+    }
+
+    /**
+     * Verifies that a non-live condition is not matched, even when an associated entity is present.
+     */
+    @Test
+    void testTrueConditionEngineWithNonLiveConditionAndAssociatedEntity() {
+        // Create a non-live condition.
+        TestCondition nonLiveCondition = new TestCondition(false, 100f);
+        List<TestCondition> list = Collections.singletonList(nonLiveCondition);
+
+        // Test match with a non-live condition and an associated entity.
+        Optional<TestCondition> result = trueConditionEngine.match(null, list, "any-key");
+
+        // Should return an empty Optional since the only condition is not live.
+        assertFalse(result.isPresent());
     }
 
     // Test implementation of Condition

--- a/bonsai-conditions/src/test/java/com/phonepe/commons/bonsai/conditions/ConditionEnginesTest.java
+++ b/bonsai-conditions/src/test/java/com/phonepe/commons/bonsai/conditions/ConditionEnginesTest.java
@@ -106,7 +106,7 @@ class ConditionEnginesTest {
      * Verifies that the 3-argument match overload also always returns true for a live condition.
      */
     @Test
-    void testTrueConditionEngineMatchWithAssociatedEntity() {
+    void testTrueConditionEngineMatchWithEntityMetadata() {
         // Test that TrueConditionEngine always returns true, ignoring the associated entity.
         assertTrue(trueConditionEngine.match(null, condition1, "any-key"));
         assertTrue(trueConditionEngine.match(null, condition2, "another-key"));
@@ -116,7 +116,7 @@ class ConditionEnginesTest {
      * Verifies the list-based match overload with an associated entity returns the first live condition.
      */
     @Test
-    void testTrueConditionEngineMatchWithListAndAssociatedEntity() {
+    void testTrueConditionEngineMatchWithListAndEntityMetadata() {
         // Test match with a list and an associated entity.
         Optional<TestCondition> result = trueConditionEngine.match(null, conditions, "any-key");
 
@@ -129,7 +129,7 @@ class ConditionEnginesTest {
      * Verifies that passing an associated entity to an empty list still results in an empty optional.
      */
     @Test
-    void testTrueConditionEngineMatchWithEmptyListAndAssociatedEntity() {
+    void testTrueConditionEngineMatchWithEmptyListAndEntityMetadata() {
         // Test match with an empty list and an associated entity.
         Optional<TestCondition> result = trueConditionEngine.match(null, Collections.emptyList(), "any-key");
 
@@ -141,7 +141,7 @@ class ConditionEnginesTest {
      * Verifies that a non-live condition is not matched, even when an associated entity is present.
      */
     @Test
-    void testTrueConditionEngineWithNonLiveConditionAndAssociatedEntity() {
+    void testTrueConditionEngineWithNonLiveConditionAndEntityMetadata() {
         // Create a non-live condition.
         TestCondition nonLiveCondition = new TestCondition(false, 100f);
         List<TestCondition> list = Collections.singletonList(nonLiveCondition);

--- a/bonsai-conditions/src/test/java/com/phonepe/commons/bonsai/conditions/MatcherTest.java
+++ b/bonsai-conditions/src/test/java/com/phonepe/commons/bonsai/conditions/MatcherTest.java
@@ -75,7 +75,6 @@ class MatcherTest {
 
             @Override
             public Boolean match(String value, TestCondition condition, String associatedEntity) {
-                // New logic for the test: match now also depends on the associatedEntity
                 boolean keyIsValid = "valid_key".equals(associatedEntity);
                 return value.length() > 5 && condition.isLive() && keyIsValid;
             }
@@ -145,7 +144,6 @@ class MatcherTest {
 
     @Test
     void testConditionalMatcherWithAssociatedEntity_Success() {
-        // Test with a value and key that both match the new logic
         Optional<TestCondition> result = conditionalMatcher.match("test string", conditions, "valid_key");
 
         assertTrue(result.isPresent());

--- a/bonsai-conditions/src/test/java/com/phonepe/commons/bonsai/conditions/MatcherTest.java
+++ b/bonsai-conditions/src/test/java/com/phonepe/commons/bonsai/conditions/MatcherTest.java
@@ -67,15 +67,15 @@ class MatcherTest {
             }
 
             @Override
-            public Optional<TestCondition> match(String value, List<TestCondition> conditionList, String associatedEntity) {
+            public Optional<TestCondition> match(String value, List<TestCondition> conditionList, String entityMetadata) {
                 return conditionList.stream()
-                        .filter(condition -> match(value, condition, associatedEntity))
+                        .filter(condition -> match(value, condition, entityMetadata))
                         .findFirst();
             }
 
             @Override
-            public Boolean match(String value, TestCondition condition, String associatedEntity) {
-                boolean keyIsValid = "valid_key".equals(associatedEntity);
+            public Boolean match(String value, TestCondition condition, String entityMetadata) {
+                boolean keyIsValid = "valid_key".equals(entityMetadata);
                 return value.length() > 5 && condition.isLive() && keyIsValid;
             }
         };
@@ -143,7 +143,7 @@ class MatcherTest {
     }
 
     @Test
-    void testConditionalMatcherWithAssociatedEntity_Success() {
+    void testConditionalMatcherWithEntityMetadata_Success() {
         Optional<TestCondition> result = conditionalMatcher.match("test string", conditions, "valid_key");
 
         assertTrue(result.isPresent());
@@ -151,17 +151,17 @@ class MatcherTest {
     }
 
     @Test
-    void testConditionalMatcherWithAssociatedEntity_Failure() {
+    void testConditionalMatcherWithEntityMetadata_Failure() {
         // Test with a valid value but an invalid key
         Optional<TestCondition> result = conditionalMatcher.match("test string", conditions, "invalid_key");
 
-        // Should fail because the associatedEntity doesn't match
+        // Should fail because the entityMetadata doesn't match
         assertFalse(result.isPresent());
     }
 
     @Test
-    void testConditionalMatcherDirectMatchWithAssociatedEntity() {
-        // Test the direct boolean-returning match method with the associatedEntity
+    void testConditionalMatcherDirectMatchWithEntityMetadata() {
+        // Test the direct boolean-returning match method with the entityMetadata
         assertTrue(conditionalMatcher.match("a long enough string", condition1, "valid_key"));
         assertFalse(conditionalMatcher.match("a long enough string", condition1, "invalid_key"));
         assertFalse(conditionalMatcher.match("short", condition1, "valid_key"));

--- a/bonsai-core/src/main/java/com/phonepe/commons/bonsai/core/vital/BonsaiTree.java
+++ b/bonsai-core/src/main/java/com/phonepe/commons/bonsai/core/vital/BonsaiTree.java
@@ -736,7 +736,7 @@ public class BonsaiTree<C extends Context> implements Bonsai<C> {
                         .map(EdgeIdentifier::getId)
                         .toList())
                 .values());
-        Optional<Edge> conditionSatisfyingEdge = variationSelectorEngine.match(context, edges);
+        Optional<Edge> conditionSatisfyingEdge = variationSelectorEngine.match(context, edges, key);
         if (conditionSatisfyingEdge.isEmpty()) {
             /* base condition for the recursion */
             if (log.isDebugEnabled()) {

--- a/bonsai-json-eval/src/main/java/com/phonepe/commons/bonsai/json/eval/GenericFilterContext.java
+++ b/bonsai-json-eval/src/main/java/com/phonepe/commons/bonsai/json/eval/GenericFilterContext.java
@@ -25,5 +25,5 @@ import lombok.Data;
 public class GenericFilterContext<C extends JsonEvalContext, F> {
     private GenericFilter genericFilter;
     private C context;
-    private F associatedEntity;
+    private F entityMetadata;
 }

--- a/bonsai-json-eval/src/main/java/com/phonepe/commons/bonsai/json/eval/GenericFilterContext.java
+++ b/bonsai-json-eval/src/main/java/com/phonepe/commons/bonsai/json/eval/GenericFilterContext.java
@@ -22,7 +22,8 @@ import lombok.Data;
 
 @Data
 @AllArgsConstructor
-public class GenericFilterContext<C extends JsonEvalContext> {
+public class GenericFilterContext<C extends JsonEvalContext, F> {
     private GenericFilter genericFilter;
     private C context;
+    private F associatedEntity;
 }

--- a/bonsai-json-eval/src/main/java/com/phonepe/commons/bonsai/json/eval/JsonPathFilterEvaluationEngine.java
+++ b/bonsai-json-eval/src/main/java/com/phonepe/commons/bonsai/json/eval/JsonPathFilterEvaluationEngine.java
@@ -56,7 +56,7 @@ import java.util.function.Predicate;
  */
 @Slf4j
 @AllArgsConstructor
-public class JsonPathFilterEvaluationEngine<C extends JsonEvalContext> implements FilterVisitor<Boolean> {
+public class JsonPathFilterEvaluationEngine<C extends JsonEvalContext, F> implements FilterVisitor<Boolean> {
 
     public static final String BONSAI_FILTER_VALUES_DOCUMENT_LOG_STR = "[bonsai][{}] filter:{} values:{} document:{}";
     private static final TypeRef<List<Number>> NUMBER_TYPE_REF = new TypeRef<>() {
@@ -69,7 +69,9 @@ public class JsonPathFilterEvaluationEngine<C extends JsonEvalContext> implement
 
     protected final C context;
 
-    private final Predicate<GenericFilterContext<C>> genericFilterHandler;
+    private final Predicate<GenericFilterContext<C, F>> genericFilterHandler;
+
+    private final F associatedEntity;
 
     @Override
     public Boolean visit(ContainsFilter filter) {
@@ -201,7 +203,7 @@ public class JsonPathFilterEvaluationEngine<C extends JsonEvalContext> implement
 
     @Override
     public Boolean visit(GenericFilter filter) {
-        final GenericFilterContext<C> genericFilterContext = new GenericFilterContext<>(filter, context);
+        final GenericFilterContext<C, F> genericFilterContext = new GenericFilterContext<>(filter, context, associatedEntity);
         return genericFilterHandler.test(genericFilterContext);
     }
 

--- a/bonsai-json-eval/src/main/java/com/phonepe/commons/bonsai/json/eval/JsonPathFilterEvaluationEngine.java
+++ b/bonsai-json-eval/src/main/java/com/phonepe/commons/bonsai/json/eval/JsonPathFilterEvaluationEngine.java
@@ -71,7 +71,7 @@ public class JsonPathFilterEvaluationEngine<C extends JsonEvalContext, F> implem
 
     private final Predicate<GenericFilterContext<C, F>> genericFilterHandler;
 
-    private final F associatedEntity;
+    private final F entityMetadata;
 
     @Override
     public Boolean visit(ContainsFilter filter) {
@@ -203,7 +203,7 @@ public class JsonPathFilterEvaluationEngine<C extends JsonEvalContext, F> implem
 
     @Override
     public Boolean visit(GenericFilter filter) {
-        final GenericFilterContext<C, F> genericFilterContext = new GenericFilterContext<>(filter, context, associatedEntity);
+        final GenericFilterContext<C, F> genericFilterContext = new GenericFilterContext<>(filter, context, entityMetadata);
         return genericFilterHandler.test(genericFilterContext);
     }
 

--- a/bonsai-json-eval/src/main/java/com/phonepe/commons/bonsai/json/eval/PathExpression.java
+++ b/bonsai-json-eval/src/main/java/com/phonepe/commons/bonsai/json/eval/PathExpression.java
@@ -69,7 +69,7 @@ public class PathExpression {
         if (filters != null && !filters.isEmpty() &&
                 !filters.stream()
                         .allMatch(k -> k.accept(new JsonPathFilterEvaluationEngine<>(key, () -> context,
-                                genericFilterContext -> true)))) {
+                                genericFilterContext -> true, key)))) {
             return null;
         }
         if (value != null) {

--- a/bonsai-json-eval/src/main/java/com/phonepe/commons/bonsai/json/eval/TraceWrappedJsonPathFilterEvaluationEngine.java
+++ b/bonsai-json-eval/src/main/java/com/phonepe/commons/bonsai/json/eval/TraceWrappedJsonPathFilterEvaluationEngine.java
@@ -42,12 +42,18 @@ import lombok.extern.slf4j.Slf4j;
 import java.util.function.Predicate;
 
 @Slf4j
-public class TraceWrappedJsonPathFilterEvaluationEngine<C extends JsonEvalContext>
-        extends JsonPathFilterEvaluationEngine<C> {
+public class TraceWrappedJsonPathFilterEvaluationEngine<C extends JsonEvalContext, F>
+        extends JsonPathFilterEvaluationEngine<C, F> {
 
     public TraceWrappedJsonPathFilterEvaluationEngine(String entityId, C context,
-                                                      Predicate<GenericFilterContext<C>> genericFilterHandler) {
-        super(entityId, context, genericFilterHandler);
+                                                      Predicate<GenericFilterContext<C, F>> genericFilterHandler) {
+        super(entityId, context, genericFilterHandler, null);
+    }
+
+    public TraceWrappedJsonPathFilterEvaluationEngine(String entityId, C context,
+                                                      Predicate<GenericFilterContext<C, F>> genericFilterHandler,
+                                                      F associatedEntity) {
+        super(entityId, context, genericFilterHandler, associatedEntity);
     }
 
     @Override

--- a/bonsai-json-eval/src/main/java/com/phonepe/commons/bonsai/json/eval/TraceWrappedJsonPathFilterEvaluationEngine.java
+++ b/bonsai-json-eval/src/main/java/com/phonepe/commons/bonsai/json/eval/TraceWrappedJsonPathFilterEvaluationEngine.java
@@ -52,8 +52,8 @@ public class TraceWrappedJsonPathFilterEvaluationEngine<C extends JsonEvalContex
 
     public TraceWrappedJsonPathFilterEvaluationEngine(String entityId, C context,
                                                       Predicate<GenericFilterContext<C, F>> genericFilterHandler,
-                                                      F associatedEntity) {
-        super(entityId, context, genericFilterHandler, associatedEntity);
+                                                      F entityMetadata) {
+        super(entityId, context, genericFilterHandler, entityMetadata);
     }
 
     @Override

--- a/bonsai-json-eval/src/test/java/com/phonepe/commons/bonsai/json/eval/GenericFilterContextTest.java
+++ b/bonsai-json-eval/src/test/java/com/phonepe/commons/bonsai/json/eval/GenericFilterContextTest.java
@@ -27,13 +27,13 @@ public class GenericFilterContextTest {
 
     private GenericFilter mockFilter;
     private JsonEvalContext mockContext;
-    private String associatedEntity;
+    private String entityMetadata;
 
     @BeforeEach
     void setUp() {
         mockFilter = Mockito.mock(GenericFilter.class);
         mockContext = Mockito.mock(JsonEvalContext.class);
-        associatedEntity = "test-key";
+        entityMetadata = "test-key";
 
         DocumentContext mockDocumentContext = Mockito.mock(DocumentContext.class);
         Mockito.when(mockContext.documentContext()).thenReturn(mockDocumentContext);
@@ -41,41 +41,41 @@ public class GenericFilterContextTest {
 
     @Test
     void testGenericFilterContextCreation() {
-        GenericFilterContext<JsonEvalContext, String> context = new GenericFilterContext<>(mockFilter, mockContext, associatedEntity);
+        GenericFilterContext<JsonEvalContext, String> context = new GenericFilterContext<>(mockFilter, mockContext, entityMetadata);
         Assertions.assertEquals(mockFilter, context.getGenericFilter());
         Assertions.assertEquals(mockContext, context.getContext());
-        Assertions.assertEquals(associatedEntity, context.getAssociatedEntity());
+        Assertions.assertEquals(entityMetadata, context.getEntityMetadata());
     }
 
     @Test
     void testGenericFilterContextSetters() {
-        GenericFilterContext<JsonEvalContext, String> context = new GenericFilterContext<>(mockFilter, mockContext, associatedEntity);
+        GenericFilterContext<JsonEvalContext, String> context = new GenericFilterContext<>(mockFilter, mockContext, entityMetadata);
         
         GenericFilter newFilter = Mockito.mock(GenericFilter.class);
         JsonEvalContext newContext = Mockito.mock(JsonEvalContext.class);
-        String newAssociatedEntity = "new-key";
+        String newEntityMetadata = "new-key";
 
         context.setGenericFilter(newFilter);
         context.setContext(newContext);
-        context.setAssociatedEntity(newAssociatedEntity);
+        context.setEntityMetadata(newEntityMetadata);
         
         Assertions.assertEquals(newFilter, context.getGenericFilter());
         Assertions.assertEquals(newContext, context.getContext());
-        Assertions.assertEquals(newAssociatedEntity, context.getAssociatedEntity());
+        Assertions.assertEquals(newEntityMetadata, context.getEntityMetadata());
     }
 
     @Test
     void testGenericFilterContextEquality() {
-        GenericFilterContext<JsonEvalContext, String> context1 = new GenericFilterContext<>(mockFilter, mockContext, associatedEntity);
-        GenericFilterContext<JsonEvalContext, String> context2 = new GenericFilterContext<>(mockFilter, mockContext, associatedEntity);
+        GenericFilterContext<JsonEvalContext, String> context1 = new GenericFilterContext<>(mockFilter, mockContext, entityMetadata);
+        GenericFilterContext<JsonEvalContext, String> context2 = new GenericFilterContext<>(mockFilter, mockContext, entityMetadata);
         
         GenericFilter differentFilter = Mockito.mock(GenericFilter.class);
         JsonEvalContext differentContext = Mockito.mock(JsonEvalContext.class);
-        String differentAssociatedEntity = "different-key";
+        String differentEntityMetadata = "different-key";
 
-        GenericFilterContext<JsonEvalContext, String> context3 = new GenericFilterContext<>(differentFilter, mockContext,associatedEntity);
-        GenericFilterContext<JsonEvalContext, String> context4 = new GenericFilterContext<>(mockFilter, differentContext, associatedEntity);
-        GenericFilterContext<JsonEvalContext, String> context5 = new GenericFilterContext<>(mockFilter, mockContext, differentAssociatedEntity);
+        GenericFilterContext<JsonEvalContext, String> context3 = new GenericFilterContext<>(differentFilter, mockContext,entityMetadata);
+        GenericFilterContext<JsonEvalContext, String> context4 = new GenericFilterContext<>(mockFilter, differentContext, entityMetadata);
+        GenericFilterContext<JsonEvalContext, String> context5 = new GenericFilterContext<>(mockFilter, mockContext, differentEntityMetadata);
         
         Assertions.assertEquals(context1, context2);
         Assertions.assertNotEquals(context1, context3);
@@ -85,20 +85,20 @@ public class GenericFilterContextTest {
 
     @Test
     void testGenericFilterContextHashCode() {
-        GenericFilterContext<JsonEvalContext, String> context1 = new GenericFilterContext<>(mockFilter, mockContext, associatedEntity);
-        GenericFilterContext<JsonEvalContext, String> context2 = new GenericFilterContext<>(mockFilter, mockContext, associatedEntity);
+        GenericFilterContext<JsonEvalContext, String> context1 = new GenericFilterContext<>(mockFilter, mockContext, entityMetadata);
+        GenericFilterContext<JsonEvalContext, String> context2 = new GenericFilterContext<>(mockFilter, mockContext, entityMetadata);
         
         Assertions.assertEquals(context1.hashCode(), context2.hashCode());
     }
 
     @Test
     void testGenericFilterContextToString() {
-        GenericFilterContext<JsonEvalContext, String> context = new GenericFilterContext<>(mockFilter, mockContext, associatedEntity);
+        GenericFilterContext<JsonEvalContext, String> context = new GenericFilterContext<>(mockFilter, mockContext, entityMetadata);
         String toString = context.toString();
         
         Assertions.assertNotNull(toString);
         Assertions.assertTrue(toString.contains("genericFilter"));
         Assertions.assertTrue(toString.contains("context"));
-        Assertions.assertTrue(toString.contains("associatedEntity"));
+        Assertions.assertTrue(toString.contains("entityMetadata"));
     }
 }

--- a/bonsai-json-eval/src/test/java/com/phonepe/commons/bonsai/json/eval/GenericFilterContextTest.java
+++ b/bonsai-json-eval/src/test/java/com/phonepe/commons/bonsai/json/eval/GenericFilterContextTest.java
@@ -27,67 +27,78 @@ public class GenericFilterContextTest {
 
     private GenericFilter mockFilter;
     private JsonEvalContext mockContext;
+    private String associatedEntity;
 
     @BeforeEach
     void setUp() {
         mockFilter = Mockito.mock(GenericFilter.class);
         mockContext = Mockito.mock(JsonEvalContext.class);
+        associatedEntity = "test-key";
+
         DocumentContext mockDocumentContext = Mockito.mock(DocumentContext.class);
         Mockito.when(mockContext.documentContext()).thenReturn(mockDocumentContext);
     }
 
     @Test
     void testGenericFilterContextCreation() {
-        GenericFilterContext<JsonEvalContext> context = new GenericFilterContext<>(mockFilter, mockContext);
+        GenericFilterContext<JsonEvalContext, String> context = new GenericFilterContext<>(mockFilter, mockContext, associatedEntity);
         Assertions.assertEquals(mockFilter, context.getGenericFilter());
         Assertions.assertEquals(mockContext, context.getContext());
+        Assertions.assertEquals(associatedEntity, context.getAssociatedEntity());
     }
 
     @Test
     void testGenericFilterContextSetters() {
-        GenericFilterContext<JsonEvalContext> context = new GenericFilterContext<>(mockFilter, mockContext);
+        GenericFilterContext<JsonEvalContext, String> context = new GenericFilterContext<>(mockFilter, mockContext, associatedEntity);
         
         GenericFilter newFilter = Mockito.mock(GenericFilter.class);
         JsonEvalContext newContext = Mockito.mock(JsonEvalContext.class);
-        
+        String newAssociatedEntity = "new-key";
+
         context.setGenericFilter(newFilter);
         context.setContext(newContext);
+        context.setAssociatedEntity(newAssociatedEntity);
         
         Assertions.assertEquals(newFilter, context.getGenericFilter());
         Assertions.assertEquals(newContext, context.getContext());
+        Assertions.assertEquals(newAssociatedEntity, context.getAssociatedEntity());
     }
 
     @Test
     void testGenericFilterContextEquality() {
-        GenericFilterContext<JsonEvalContext> context1 = new GenericFilterContext<>(mockFilter, mockContext);
-        GenericFilterContext<JsonEvalContext> context2 = new GenericFilterContext<>(mockFilter, mockContext);
+        GenericFilterContext<JsonEvalContext, String> context1 = new GenericFilterContext<>(mockFilter, mockContext, associatedEntity);
+        GenericFilterContext<JsonEvalContext, String> context2 = new GenericFilterContext<>(mockFilter, mockContext, associatedEntity);
         
         GenericFilter differentFilter = Mockito.mock(GenericFilter.class);
         JsonEvalContext differentContext = Mockito.mock(JsonEvalContext.class);
-        
-        GenericFilterContext<JsonEvalContext> context3 = new GenericFilterContext<>(differentFilter, mockContext);
-        GenericFilterContext<JsonEvalContext> context4 = new GenericFilterContext<>(mockFilter, differentContext);
+        String differentAssociatedEntity = "different-key";
+
+        GenericFilterContext<JsonEvalContext, String> context3 = new GenericFilterContext<>(differentFilter, mockContext,associatedEntity);
+        GenericFilterContext<JsonEvalContext, String> context4 = new GenericFilterContext<>(mockFilter, differentContext, associatedEntity);
+        GenericFilterContext<JsonEvalContext, String> context5 = new GenericFilterContext<>(mockFilter, mockContext, differentAssociatedEntity);
         
         Assertions.assertEquals(context1, context2);
         Assertions.assertNotEquals(context1, context3);
         Assertions.assertNotEquals(context1, context4);
+        Assertions.assertNotEquals(context1, context5);
     }
 
     @Test
     void testGenericFilterContextHashCode() {
-        GenericFilterContext<JsonEvalContext> context1 = new GenericFilterContext<>(mockFilter, mockContext);
-        GenericFilterContext<JsonEvalContext> context2 = new GenericFilterContext<>(mockFilter, mockContext);
+        GenericFilterContext<JsonEvalContext, String> context1 = new GenericFilterContext<>(mockFilter, mockContext, associatedEntity);
+        GenericFilterContext<JsonEvalContext, String> context2 = new GenericFilterContext<>(mockFilter, mockContext, associatedEntity);
         
         Assertions.assertEquals(context1.hashCode(), context2.hashCode());
     }
 
     @Test
     void testGenericFilterContextToString() {
-        GenericFilterContext<JsonEvalContext> context = new GenericFilterContext<>(mockFilter, mockContext);
+        GenericFilterContext<JsonEvalContext, String> context = new GenericFilterContext<>(mockFilter, mockContext, associatedEntity);
         String toString = context.toString();
         
         Assertions.assertNotNull(toString);
         Assertions.assertTrue(toString.contains("genericFilter"));
         Assertions.assertTrue(toString.contains("context"));
+        Assertions.assertTrue(toString.contains("associatedEntity"));
     }
 }

--- a/bonsai-json-eval/src/test/java/com/phonepe/commons/bonsai/json/eval/JsonPathEvaluationTest.java
+++ b/bonsai-json-eval/src/test/java/com/phonepe/commons/bonsai/json/eval/JsonPathEvaluationTest.java
@@ -19,12 +19,14 @@ package com.phonepe.commons.bonsai.json.eval;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.jayway.jsonpath.JsonPath;
 import com.phonepe.commons.query.dsl.Filter;
+import com.phonepe.commons.query.dsl.general.GenericFilter;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 
 public class JsonPathEvaluationTest {
 
@@ -34,9 +36,9 @@ public class JsonPathEvaluationTest {
     void testJsonPathEval() throws IOException {
         JsonPathSetup.setup();
         Map object = objectExtractor.getObject("sample.json", Map.class);
-        JsonPathFilterEvaluationEngine<JsonEvalContext> eval
+        JsonPathFilterEvaluationEngine<JsonEvalContext, String> eval
                 = new JsonPathFilterEvaluationEngine<>("temp", () -> JsonPath.parse(object),
-                genericFilterContext -> true);
+                genericFilterContext -> true, null);
         List<Filter> filters = objectExtractor.getObject("filterList1.json", new TypeReference<>() {
         });
         long count = filters.stream()
@@ -49,7 +51,7 @@ public class JsonPathEvaluationTest {
     void testJsonPathEvalWithTrace() throws IOException {
         JsonPathSetup.setup();
         Map object = objectExtractor.getObject("sample.json", Map.class);
-        JsonPathFilterEvaluationEngine<JsonEvalContext> eval
+        JsonPathFilterEvaluationEngine<JsonEvalContext, String> eval
                 = new TraceWrappedJsonPathFilterEvaluationEngine<>("temp", () -> JsonPath.parse(object),
                 genericFilterContext -> true);
         List<Filter> filters = objectExtractor.getObject("filterList1.json", new TypeReference<>() {
@@ -58,5 +60,41 @@ public class JsonPathEvaluationTest {
                 .filter(filter -> filter.accept(eval))
                 .count();
         Assertions.assertEquals(8, count);
+    }
+
+    @Test
+    void testJsonPathEval_WithAssociatedEntity() throws IOException {
+        JsonPathSetup.setup();
+        Map<String, Object> object = objectExtractor.getObject("sample.json", Map.class);
+        GenericFilter genericFilter = new GenericFilter(); // The logic is in the handler.
+        String expectedKey = "user-segment-A";
+
+        // 1. Create a handler that checks the associatedEntity.
+        Predicate<GenericFilterContext<JsonEvalContext, String>> handler =
+                ctx -> expectedKey.equals(ctx.getAssociatedEntity());
+
+        // 2. Test the positive case: engine is created with the correct key.
+        JsonPathFilterEvaluationEngine<JsonEvalContext, String> evalWithCorrectKey =
+                new JsonPathFilterEvaluationEngine<>(
+                        "test-entity",
+                        () -> JsonPath.parse(object),
+                        handler,
+                        expectedKey
+                );
+
+        boolean result1 = genericFilter.accept(evalWithCorrectKey);
+        Assertions.assertTrue(result1, "Filter should pass when associatedEntity matches.");
+
+        // 3. Test the negative case: engine is created with an incorrect key.
+        JsonPathFilterEvaluationEngine<JsonEvalContext, String> evalWithWrongKey =
+                new JsonPathFilterEvaluationEngine<>(
+                        "test-entity",
+                        () -> JsonPath.parse(object),
+                        handler,
+                        "wrong-key"
+                );
+
+        boolean result2 = genericFilter.accept(evalWithWrongKey);
+        Assertions.assertFalse(result2, "Filter should fail when associatedEntity does not match.");
     }
 }

--- a/bonsai-json-eval/src/test/java/com/phonepe/commons/bonsai/json/eval/JsonPathEvaluationTest.java
+++ b/bonsai-json-eval/src/test/java/com/phonepe/commons/bonsai/json/eval/JsonPathEvaluationTest.java
@@ -63,15 +63,15 @@ public class JsonPathEvaluationTest {
     }
 
     @Test
-    void testJsonPathEval_WithAssociatedEntity() throws IOException {
+    void testJsonPathEval_WithEntityMetadata() throws IOException {
         JsonPathSetup.setup();
         Map<String, Object> object = objectExtractor.getObject("sample.json", Map.class);
         GenericFilter genericFilter = new GenericFilter(); // The logic is in the handler.
         String expectedKey = "user-segment-A";
 
-        // 1. Create a handler that checks the associatedEntity.
+        // 1. Create a handler that checks the entityMetadata.
         Predicate<GenericFilterContext<JsonEvalContext, String>> handler =
-                ctx -> expectedKey.equals(ctx.getAssociatedEntity());
+                ctx -> expectedKey.equals(ctx.getEntityMetadata());
 
         // 2. Test the positive case: engine is created with the correct key.
         JsonPathFilterEvaluationEngine<JsonEvalContext, String> evalWithCorrectKey =
@@ -83,7 +83,7 @@ public class JsonPathEvaluationTest {
                 );
 
         boolean result1 = genericFilter.accept(evalWithCorrectKey);
-        Assertions.assertTrue(result1, "Filter should pass when associatedEntity matches.");
+        Assertions.assertTrue(result1, "Filter should pass when entityMetadata matches.");
 
         // 3. Test the negative case: engine is created with an incorrect key.
         JsonPathFilterEvaluationEngine<JsonEvalContext, String> evalWithWrongKey =
@@ -95,6 +95,6 @@ public class JsonPathEvaluationTest {
                 );
 
         boolean result2 = genericFilter.accept(evalWithWrongKey);
-        Assertions.assertFalse(result2, "Filter should fail when associatedEntity does not match.");
+        Assertions.assertFalse(result2, "Filter should fail when entityMetadata does not match.");
     }
 }

--- a/bonsai-json-eval/src/test/java/com/phonepe/commons/bonsai/json/eval/JsonPathFilterEvaluationEngineTest.java
+++ b/bonsai-json-eval/src/test/java/com/phonepe/commons/bonsai/json/eval/JsonPathFilterEvaluationEngineTest.java
@@ -57,8 +57,8 @@ public class JsonPathFilterEvaluationEngineTest {
 
     private DocumentContext mockDocumentContext;
     private JsonEvalContext mockContext;
-    private Predicate<GenericFilterContext<JsonEvalContext>> mockGenericFilterHandler;
-    private JsonPathFilterEvaluationEngine<JsonEvalContext> engine;
+    private Predicate<GenericFilterContext<JsonEvalContext, String>> mockGenericFilterHandler;
+    private JsonPathFilterEvaluationEngine<JsonEvalContext, String> engine;
 
     @BeforeEach
     @SuppressWarnings("unchecked")
@@ -71,7 +71,7 @@ public class JsonPathFilterEvaluationEngineTest {
         Mockito.when(mockContext.documentContext()).thenReturn(mockDocumentContext);
         Mockito.when(mockContext.id()).thenReturn("test-id");
         
-        engine = new JsonPathFilterEvaluationEngine<>("test-entity", mockContext, mockGenericFilterHandler);
+        engine = new JsonPathFilterEvaluationEngine<>("test-entity", mockContext, mockGenericFilterHandler, "key");
     }
 
     @Test

--- a/bonsai-json-eval/src/test/java/com/phonepe/commons/bonsai/json/eval/TraceWrappedJsonPathFilterEvaluationEngineTest.java
+++ b/bonsai-json-eval/src/test/java/com/phonepe/commons/bonsai/json/eval/TraceWrappedJsonPathFilterEvaluationEngineTest.java
@@ -363,7 +363,6 @@ public class TraceWrappedJsonPathFilterEvaluationEngineTest {
 
     @Test
     void testVisitGenericFilter_WithAssociatedEntity() {
-        // Arrange: Create an engine instance with a specific associatedEntity.
         String testKey = "my-special-key";
         TraceWrappedJsonPathFilterEvaluationEngine<JsonEvalContext, String> engineWithKey =
                 new TraceWrappedJsonPathFilterEvaluationEngine<>("test-entity", mockContext, mockGenericFilterHandler, testKey);
@@ -373,11 +372,9 @@ public class TraceWrappedJsonPathFilterEvaluationEngineTest {
         Mockito.when(mockGenericFilterHandler.test(any(GenericFilterContext.class)))
                 .thenReturn(true);
 
-        // Use an ArgumentCaptor to capture the context passed to the handler.
         ArgumentCaptor<GenericFilterContext<JsonEvalContext, String>> contextCaptor =
                 ArgumentCaptor.forClass(GenericFilterContext.class);
 
-        // Act
         engineWithKey.visit(filter);
 
         // Assert: Verify the handler was called and capture the argument.

--- a/bonsai-json-eval/src/test/java/com/phonepe/commons/bonsai/json/eval/TraceWrappedJsonPathFilterEvaluationEngineTest.java
+++ b/bonsai-json-eval/src/test/java/com/phonepe/commons/bonsai/json/eval/TraceWrappedJsonPathFilterEvaluationEngineTest.java
@@ -362,7 +362,7 @@ public class TraceWrappedJsonPathFilterEvaluationEngineTest {
     }
 
     @Test
-    void testVisitGenericFilter_WithAssociatedEntity() {
+    void testVisitGenericFilter_WithEntityMetadata() {
         String testKey = "my-special-key";
         TraceWrappedJsonPathFilterEvaluationEngine<JsonEvalContext, String> engineWithKey =
                 new TraceWrappedJsonPathFilterEvaluationEngine<>("test-entity", mockContext, mockGenericFilterHandler, testKey);
@@ -380,7 +380,7 @@ public class TraceWrappedJsonPathFilterEvaluationEngineTest {
         // Assert: Verify the handler was called and capture the argument.
         Mockito.verify(mockGenericFilterHandler).test(contextCaptor.capture());
 
-        // Check that the captured context contains the correct associatedEntity.
-        Assertions.assertEquals(testKey, contextCaptor.getValue().getAssociatedEntity());
+        // Check that the captured context contains the correct entityMetadata.
+        Assertions.assertEquals(testKey, contextCaptor.getValue().getEntityMetadata());
     }
 }

--- a/bonsai-json-eval/src/test/java/com/phonepe/commons/bonsai/json/eval/TraceWrappedJsonPathFilterEvaluationEngineTest.java
+++ b/bonsai-json-eval/src/test/java/com/phonepe/commons/bonsai/json/eval/TraceWrappedJsonPathFilterEvaluationEngineTest.java
@@ -41,6 +41,7 @@ import com.phonepe.commons.query.dsl.string.StringStartsWithFilter;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import java.util.Arrays;
@@ -55,8 +56,8 @@ public class TraceWrappedJsonPathFilterEvaluationEngineTest {
 
     private DocumentContext mockDocumentContext;
     private JsonEvalContext mockContext;
-    private Predicate<GenericFilterContext<JsonEvalContext>> mockGenericFilterHandler;
-    private TraceWrappedJsonPathFilterEvaluationEngine<JsonEvalContext> engine;
+    private Predicate<GenericFilterContext<JsonEvalContext, String>> mockGenericFilterHandler;
+    private TraceWrappedJsonPathFilterEvaluationEngine<JsonEvalContext, String> engine;
 
     @BeforeEach
     @SuppressWarnings("unchecked")
@@ -343,8 +344,8 @@ public class TraceWrappedJsonPathFilterEvaluationEngineTest {
     @Test
     void testTraceWrappedVsRegularEngine() {
         // Create both engines with the same parameters
-        JsonPathFilterEvaluationEngine<JsonEvalContext> regularEngine = 
-                new JsonPathFilterEvaluationEngine<>("test-entity", mockContext, mockGenericFilterHandler);
+        JsonPathFilterEvaluationEngine<JsonEvalContext, String> regularEngine =
+                new JsonPathFilterEvaluationEngine<>("test-entity", mockContext, mockGenericFilterHandler, "Key");
         
         // Test that both engines return the same result for the same input
         EqualsFilter filter = new EqualsFilter();
@@ -358,5 +359,31 @@ public class TraceWrappedJsonPathFilterEvaluationEngineTest {
         Boolean traceResult = engine.visit(filter);
         
         Assertions.assertEquals(regularResult, traceResult);
+    }
+
+    @Test
+    void testVisitGenericFilter_WithAssociatedEntity() {
+        // Arrange: Create an engine instance with a specific associatedEntity.
+        String testKey = "my-special-key";
+        TraceWrappedJsonPathFilterEvaluationEngine<JsonEvalContext, String> engineWithKey =
+                new TraceWrappedJsonPathFilterEvaluationEngine<>("test-entity", mockContext, mockGenericFilterHandler, testKey);
+
+        GenericFilter filter = Mockito.mock(GenericFilter.class);
+
+        Mockito.when(mockGenericFilterHandler.test(any(GenericFilterContext.class)))
+                .thenReturn(true);
+
+        // Use an ArgumentCaptor to capture the context passed to the handler.
+        ArgumentCaptor<GenericFilterContext<JsonEvalContext, String>> contextCaptor =
+                ArgumentCaptor.forClass(GenericFilterContext.class);
+
+        // Act
+        engineWithKey.visit(filter);
+
+        // Assert: Verify the handler was called and capture the argument.
+        Mockito.verify(mockGenericFilterHandler).test(contextCaptor.capture());
+
+        // Check that the captured context contains the correct associatedEntity.
+        Assertions.assertEquals(testKey, contextCaptor.getValue().getAssociatedEntity());
     }
 }


### PR DESCRIPTION
This change introduces key-aware filtering capabilities into the core evaluation engine by passing the evaluation key down to the filter execution layer. This is achieved by adding a generic associatedEntity field to the ConditionEngine and ConditionalMatcher interfaces, which is then populated with the current evaluation key in BonsaiTree.

This enhancement is foundational for enabling new filter Uniform Sampling Filter.

Bonsai's evaluation engine is the only component with direct, real-time access to the full context required for these new filter. The current key is only available within the BonsaiTree.evaluate() call stack. Placing the logic in Bonsai is efficient, as it avoids a complex and slow process of passing context back and forth with the consuming application.

