### PR TITLE
Fix: Numeric Comparison Precision Loss in JsonPathFilterEvaluationEngine [From: Deepanjan-Fork Repo]

### DIFF
--- a/bonsai-json-eval/src/main/java/com/phonepe/commons/bonsai/json/eval/JsonPathFilterEvaluationEngine.java
+++ b/bonsai-json-eval/src/main/java/com/phonepe/commons/bonsai/json/eval/JsonPathFilterEvaluationEngine.java
@@ -239,24 +239,24 @@ public class JsonPathFilterEvaluationEngine<C extends JsonEvalContext, F> implem
     }
 
     private Predicate<Number> lessThan(NumericBinaryFilter filter) {
-        return k -> k.floatValue() < filter.getValue().floatValue();
+        return k -> k.doubleValue() < filter.getValue().doubleValue();
     }
 
     private Predicate<Number> lessThanEquals(NumericBinaryFilter filter) {
-        return k -> k.floatValue() <= filter.getValue().floatValue();
+        return k -> k.doubleValue() <= filter.getValue().doubleValue();
     }
 
     private Predicate<Number> greaterThan(NumericBinaryFilter filter) {
-        return k -> k.floatValue() > filter.getValue().floatValue();
+        return k -> k.doubleValue() > filter.getValue().doubleValue();
     }
 
     private Predicate<Number> between(BetweenFilter filter) {
-        return k -> k.floatValue() > filter.getFrom().floatValue()
-                && k.floatValue() < filter.getTo().floatValue();
+        return k -> k.doubleValue() > filter.getFrom().doubleValue()
+                && k.doubleValue() < filter.getTo().doubleValue();
     }
 
     private Predicate<Number> greaterThanEquals(NumericBinaryFilter filter) {
-        return k -> k.floatValue() >= filter.getValue().floatValue();
+        return k -> k.doubleValue() >= filter.getValue().doubleValue();
     }
 
     private Predicate<Object> equalsFilter(EqualsFilter filter) {

--- a/bonsai-json-eval/src/test/java/com/phonepe/commons/bonsai/json/eval/JsonPathFilterEvaluationEngineTest.java
+++ b/bonsai-json-eval/src/test/java/com/phonepe/commons/bonsai/json/eval/JsonPathFilterEvaluationEngineTest.java
@@ -607,4 +607,132 @@ public class JsonPathFilterEvaluationEngineTest {
         Boolean result = engine.visit(filter);
         Assertions.assertTrue(result);
     }
+
+    @Test
+    void testLessThanFilterWithLargeIntegers() {
+        LessThanFilter filter = new LessThanFilter();
+        filter.setField("$.data.value");
+        filter.setValue(26011304);
+        
+        // Test with value less by 1 - this would fail with floatValue() due to precision loss
+        Mockito.when(mockDocumentContext.read(eq("$.data.value"), any(TypeRef.class)))
+                .thenReturn(Collections.singletonList(26011303));
+        
+        Boolean result = engine.visit(filter);
+        Assertions.assertTrue(result, "26011303 should be less than 26011304");
+        
+        // Test with value less by 2
+        Mockito.when(mockDocumentContext.read(eq("$.data.value"), any(TypeRef.class)))
+                .thenReturn(Collections.singletonList(26011302));
+        
+        result = engine.visit(filter);
+        Assertions.assertTrue(result, "26011302 should be less than 26011304");
+        
+        // Test with equal value
+        Mockito.when(mockDocumentContext.read(eq("$.data.value"), any(TypeRef.class)))
+                .thenReturn(Collections.singletonList(26011304));
+        
+        result = engine.visit(filter);
+        Assertions.assertFalse(result, "26011304 should not be less than 26011304");
+        
+        // Test with greater value
+        Mockito.when(mockDocumentContext.read(eq("$.data.value"), any(TypeRef.class)))
+                .thenReturn(Collections.singletonList(26011305));
+        
+        result = engine.visit(filter);
+        Assertions.assertFalse(result, "26011305 should not be less than 26011304");
+    }
+
+    @Test
+    void testLessEqualFilterWithLargeIntegers() {
+        LessEqualFilter filter = new LessEqualFilter();
+        filter.setField("$.data.value");
+        filter.setValue(26011304);
+        
+        // Test exact equality
+        Mockito.when(mockDocumentContext.read(eq("$.data.value"), any(TypeRef.class)))
+                .thenReturn(Collections.singletonList(26011304));
+        
+        Boolean result = engine.visit(filter);
+        Assertions.assertTrue(result, "26011304 should be less than or equal to 26011304");
+        
+        // Test less than by 1
+        Mockito.when(mockDocumentContext.read(eq("$.data.value"), any(TypeRef.class)))
+                .thenReturn(Collections.singletonList(26011303));
+        
+        result = engine.visit(filter);
+        Assertions.assertTrue(result, "26011303 should be less than or equal to 26011304");
+    }
+
+    @Test
+    void testGreaterThanFilterWithLargeIntegers() {
+        GreaterThanFilter filter = new GreaterThanFilter();
+        filter.setField("$.data.value");
+        filter.setValue(26011303);
+        
+        // Test greater by 1
+        Mockito.when(mockDocumentContext.read(eq("$.data.value"), any(TypeRef.class)))
+                .thenReturn(Collections.singletonList(26011304));
+        
+        Boolean result = engine.visit(filter);
+        Assertions.assertTrue(result, "26011304 should be greater than 26011303");
+        
+        // Test not greater
+        Mockito.when(mockDocumentContext.read(eq("$.data.value"), any(TypeRef.class)))
+                .thenReturn(Collections.singletonList(26011303));
+        
+        result = engine.visit(filter);
+        Assertions.assertFalse(result, "26011303 should not be greater than 26011303");
+    }
+
+    @Test
+    void testGreaterEqualFilterWithLargeIntegers() {
+        GreaterEqualFilter filter = new GreaterEqualFilter();
+        filter.setField("$.data.value");
+        filter.setValue(26011303);
+        
+        // Test exact equality
+        Mockito.when(mockDocumentContext.read(eq("$.data.value"), any(TypeRef.class)))
+                .thenReturn(Collections.singletonList(26011303));
+        
+        Boolean result = engine.visit(filter);
+        Assertions.assertTrue(result, "26011303 should be greater than or equal to 26011303");
+        
+        // Test greater by 1
+        Mockito.when(mockDocumentContext.read(eq("$.data.value"), any(TypeRef.class)))
+                .thenReturn(Collections.singletonList(26011304));
+        
+        result = engine.visit(filter);
+        Assertions.assertTrue(result, "26011304 should be greater than or equal to 26011303");
+    }
+
+    @Test
+    void testBetweenFilterWithLargeIntegers() {
+        BetweenFilter filter = new BetweenFilter();
+        filter.setField("$.data.value");
+        filter.setFrom(26011302);
+        filter.setTo(26011305);
+        
+        // Test value in range
+        Mockito.when(mockDocumentContext.read(eq("$.data.value"), any(TypeRef.class)))
+                .thenReturn(Collections.singletonList(26011303));
+        
+        Boolean result = engine.visit(filter);
+        Assertions.assertTrue(result, "26011303 should be between 26011302 and 26011305");
+        
+        // Test value at lower bound (exclusive)
+        Mockito.when(mockDocumentContext.read(eq("$.data.value"), any(TypeRef.class)))
+                .thenReturn(Collections.singletonList(26011302));
+        
+        result = engine.visit(filter);
+        Assertions.assertFalse(result, "26011302 should not be between 26011302 and 26011305 (exclusive bounds)");
+        
+        // Test value at upper bound (exclusive)
+        Mockito.when(mockDocumentContext.read(eq("$.data.value"), any(TypeRef.class)))
+                .thenReturn(Collections.singletonList(26011305));
+        
+        result = engine.visit(filter);
+        Assertions.assertFalse(result, "26011305 should not be between 26011302 and 26011305 (exclusive bounds)");
+    }
 }
+


### PR DESCRIPTION
## Problem
Numeric filter comparisons (less than, greater than, etc.) were using `floatValue()` for comparisons, which caused precision loss for large integers. This resulted in incorrect filter evaluation results.
     
### Example of the Bug
```java
// Before fix (using floatValue):
26011303 < 26011304  // Returns FALSE (incorrect!)
// Both values convert to same float: 2.6011304E7
     
// After fix (using doubleValue):
26011303 < 26011304  // Returns TRUE (correct!)
// Values preserved: 2.6011303E7 vs 2.6011304E7
```
### Root Cause
Float has only ~7 significant decimal digits of precision, while double has ~15-17 significant digits.

### Solution
Changed all numeric comparison methods in JsonPathFilterEvaluationEngine from using floatValue() to doubleValue():
     - lessThan()
     - lessThanEquals()
     - greaterThan()
     - greaterThanEquals()
     - between()

### Testing
Added comprehensive test coverage for large integer comparisons:
     - **testLessThanFilterWithLargeIntegers** - Tests < operator with large integers
     - **testLessEqualFilterWithLargeIntegers** - Tests <= operator with large integers
     - **testGreaterThanFilterWithLargeIntegers** - Tests > operator with large integers
     - **testGreaterEqualFilterWithLargeIntegers** - Tests >= operator with large integers
     - **testBetweenFilterWithLargeIntegers** - Tests between filter with large integers

_All existing tests (90 total) continue to pass, ensuring no regressions._