### PR TITLE
Update hope lang version 2.0.9->2.0.10

### DIFF
--- a/bonsai-json-eval/pom.xml
+++ b/bonsai-json-eval/pom.xml
@@ -12,7 +12,7 @@
 
     <properties>
         <json-path.version>2.9.0</json-path.version>
-        <hope.version>2.0.9</hope.version>
+        <hope.version>2.0.10</hope.version>
         <javassist.version>3.28.0-GA</javassist.version>
     </properties>
 


### PR DESCRIPTION
The new hope-lang version comes with the following fixes:

1. [Fix infinite recursion in Converters.jsonNodeToValue for nested arrays; add arr.* regression tests](https://github.com/santanusinha/hope/pull/47)
2. [Fix: use eval cache in explodeArray; add ExplodeArrayCacheTest](https://github.com/santanusinha/hope/pull/48)